### PR TITLE
Prevent crash when processing molecules with 0 rotatable bonds

### DIFF
--- a/diffusion/likelihood.py
+++ b/diffusion/likelihood.py
@@ -92,8 +92,12 @@ def log_det_jac(data):
         dx = dx - np.cross(omega, pos)
         jac.append(dx.flatten())
     jac = np.array(jac)
-    _, D, _ = np.linalg.svd(jac)
-    return np.sum(np.log(D))
+    try:
+        _, D, _ = np.linalg.svd(jac)
+        return np.sum(np.log(D))
+    except:
+        ## in case there are 0 rotatable bonds, return 0
+        return 0
 
 
 kT = 0.592

--- a/diffusion/likelihood.py
+++ b/diffusion/likelihood.py
@@ -95,10 +95,12 @@ def log_det_jac(data):
     try:
         _, D, _ = np.linalg.svd(jac)
         return np.sum(np.log(D))
-    except:
-        ## in case there are 0 rotatable bonds, return 0
-        return 0
-
+    except Exception as e:
+        if data.edge_mask.sum() < 0.5:
+            ## in case there are 0 rotatable bonds, return 0
+            return 0
+        else:
+            raise e
 
 kT = 0.592
 def free_energy(dlogp, energy, bootstrap_=True):


### PR DESCRIPTION
There is a bug when processing a structure which doesn't contain any rotatable bonds. When this happens, the program crashes when trying to calculate the log_det_jac. This fix can catch this error by returning 0 instead. There might be better ways to fix this, but at least it prevents a crash.